### PR TITLE
fix(react-native): react-native-community PushNotificationIOS

### DIFF
--- a/component/index.ios.js
+++ b/component/index.ios.js
@@ -2,8 +2,8 @@
 
 import {
   AppState,
-  PushNotificationIOS
 } from 'react-native';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
 
 module.exports = {
   state: AppState,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "type": "git",
     "url": "git+ssh://git@github.com:zo0r/react-native-push-notification.git"
   },
+  "dependencies": {
+    "@react-native-community/push-notification-ios": "^1.0.0"
+  },
   "peerDependencies": {
     "react-native": ">=0.33"
   },


### PR DESCRIPTION
PushNotificationIOS has been deprecated in react-native and moved into its own repo. This switches to using the react-native-community version to work with newer versions.