### PR TITLE
fix: trigger Android onNotification for Leanplum push

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -76,7 +76,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         Bundle bundle = null;
         if (intent.hasExtra("notification")) {
             bundle = intent.getBundleExtra("notification");
-        } else if (intent.hasExtra("google.message_id")) {
+        } else if (intent.hasExtra("google.message_id") || intent.hasExtra("lp_messageId")) {
             bundle = intent.getExtras();
         }
         return bundle;


### PR DESCRIPTION
## Description
Android onNotification is not triggered because of the different format of Leanplum push notification. This grabs extras to set the bundle when `lp_messageId` presents.