### PR TITLE
fix: set bundle to be uri that intent is operating on

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -78,6 +78,9 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
             bundle = intent.getBundleExtra("notification");
         } else if (intent.hasExtra("google.message_id") || intent.hasExtra("lp_messageId")) {
             bundle = intent.getExtras();
+        } else if (intent.getData() != null) {
+            intent.putExtra("uri", intent.getData());
+            bundle = intent.getExtras();
         }
         return bundle;
     }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -78,7 +78,11 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
             bundle = intent.getBundleExtra("notification");
         } else if (intent.hasExtra("google.message_id") || intent.hasExtra("lp_messageId")) {
             bundle = intent.getExtras();
-        } else if (intent.getData() != null) {
+        /**
+         * This is used for push notification from Leanplum with deeplink,
+         * which has extras as null, uri as data and includes package name.
+         */
+        } else if (intent.getData() != null && intent.getPackage() != null) {
             intent.putExtra("uri", intent.getData());
             bundle = intent.getExtras();
         }


### PR DESCRIPTION
## Description
When getting push notification with link form Leanplum, the content won't be set as extras on the intent. Instead, we get the data uri the intent is operating on. In this case, we'd want to set it as bundle and sending back to JavaScript for onNotification.

More info on getData() https://developer.android.com/reference/android/content/Intent#getData()